### PR TITLE
Fixed Desync issue for Neotanks and destroyed Pipeseams

### DIFF
--- a/AWBWApp.Game.Tests/Visual/Screens/TestScenePlayerDisplay.cs
+++ b/AWBWApp.Game.Tests/Visual/Screens/TestScenePlayerDisplay.cs
@@ -8,6 +8,7 @@ using AWBWApp.Game.Game.Units;
 using AWBWApp.Game.UI.Replay;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -21,6 +22,7 @@ namespace AWBWApp.Game.Tests.Visual.Screens
     public partial class TestScenePlayerDisplay : AWBWAppTestScene
     {
         private PlayerInfo playerInfo;
+            IBindable<bool> showClock;
 
         [Resolved]
         private COStorage coStorage { get; set; }
@@ -31,32 +33,32 @@ namespace AWBWApp.Game.Tests.Visual.Screens
         [Test]
         public void TestCreateReplayPlayer()
         {
-            AddStep("Create Replay Player", () => reset(false, false));
+            AddStep("Create Replay Player", () => reset(false, false,showClock));
             addTests(false);
         }
 
         [Test]
         public void TestCreateReplayPlayerWithTeam()
         {
-            AddStep("Create Replay Player", () => reset(true, false));
+            AddStep("Create Replay Player", () => reset(true, false,showClock));
             addTests(false);
         }
 
         [Test]
         public void TestCreateReplayPlayerWithTag()
         {
-            AddStep("Create Replay Player", () => reset(false, true));
+            AddStep("Create Replay Player", () => reset(false, true,showClock));
             addTests(true);
         }
 
         [Test]
         public void TestCreateReplayPlayerWithTeamAndTag()
         {
-            AddStep("Create Replay Player", () => reset(true, true));
+            AddStep("Create Replay Player", () => reset(true, true,showClock));
             addTests(true);
         }
 
-        private void reset(bool addTeam, bool addTag)
+        private void reset(bool addTeam, bool addTag, IBindable<bool> showClock)
         {
             var replayPlayer = new ReplayUser
             {
@@ -110,7 +112,7 @@ namespace AWBWApp.Game.Tests.Visual.Screens
                         Colour = new Color4(42, 91, 139, 255).Lighten(0.2f),
                         Size = new Vector2(2)
                     },
-                    new ReplayPlayerListItem(null, playerInfo, null, false, x => new List<DrawableUnit>())
+                    new ReplayPlayerListItem(null, playerInfo, null, false, x => new List<DrawableUnit>(), showClock)
                 }
             };
         }

--- a/AWBWApp.Game/API/Replay/AWBWJsonReplayParser.cs
+++ b/AWBWApp.Game/API/Replay/AWBWJsonReplayParser.cs
@@ -855,8 +855,8 @@ namespace AWBWApp.Game.API.Replay
                         case "turn_clock":
                         {
                             //Describes how much time this player had at the start of the turn.
-                            //Not useful for us as we don't really care when turns begin and end.
-                            readNullableInteger(text, ref textIndex);
+                            var clock = readNullableInteger(text, ref textIndex);
+                            playerDataTurn.Clock = clock;
                             break;
                         }
 

--- a/AWBWApp.Game/API/Replay/Actions/AttackPipeUnitAction.cs
+++ b/AWBWApp.Game/API/Replay/Actions/AttackPipeUnitAction.cs
@@ -103,7 +103,7 @@ namespace AWBWApp.Game.API.Replay.Actions
 
             originalSeam = seam.Clone();
 
-            //Seems like destroyed pipe seams can have differing CP values depending on how they are destroyed. (e.g. In Fog, overkill).
+            //CP value of destroyed pipeseams in AWBW is inconsitent over time
             //This value will get set to 0 for consistency.
             if (Seam.TerrainID != originalSeam.TerrainID)
                 Seam.Capture = 0;

--- a/AWBWApp.Game/API/Replay/ReplayBuilding.cs
+++ b/AWBWApp.Game/API/Replay/ReplayBuilding.cs
@@ -37,7 +37,8 @@ namespace AWBWApp.Game.API.Replay
                 return false;
             if (Position != other.Position)
                 return false;
-            if (Capture != other.Capture)
+            //For destroyed Pipeseams Capture is undefined
+            if (TerrainID != 115 && TerrainID != 116 && Capture != other.Capture)
                 return false;
 
             return true;

--- a/AWBWApp.Game/API/Replay/ReplayUser.cs
+++ b/AWBWApp.Game/API/Replay/ReplayUser.cs
@@ -41,7 +41,8 @@ namespace AWBWApp.Game.API.Replay
         public int? TagRequiredPowerForSuper; //This changes every time we use a power.
 
         public ActiveCOPower COPowerOn;
-
+    
+        public int? Clock; //how much time player has left at start of the turn in seconds
         public bool Eliminated;
 
         public void Copy(ReplayUserTurn other)
@@ -59,6 +60,7 @@ namespace AWBWApp.Game.API.Replay
             TagRequiredPowerForNormal = other.TagRequiredPowerForNormal;
             TagRequiredPowerForSuper = other.TagRequiredPowerForSuper;
 
+            Clock = other.Clock;
             Eliminated = other.Eliminated;
         }
 

--- a/AWBWApp.Game/AWBWConfigManager.cs
+++ b/AWBWApp.Game/AWBWConfigManager.cs
@@ -62,6 +62,7 @@ namespace AWBWApp.Game
             SetDefault(AWBWSetting.ShowTileCursor, true);
             SetDefault(AWBWSetting.ShowAnimationsForHiddenActions, true);
             SetDefault(AWBWSetting.SonjaHPVisiblity, SonjaHPVisibility.AlwaysVisible);
+            SetDefault(AWBWSetting.ShowClock, true);
 
             SetDefault(AWBWSetting.MapGridBaseColour, new Colour4(42, 91, 139, 255).Lighten(0.2f));
             SetDefault(AWBWSetting.MapGridGridColour, new Colour4(42, 91, 139, 255).Darken(0.8f));
@@ -94,7 +95,8 @@ namespace AWBWApp.Game
         ShowAnimationsForHiddenActions,
         MapGridBaseColour,
         MapGridGridColour,
-        SonjaHPVisiblity
+        SonjaHPVisiblity,
+        ShowClock
     }
 
     public enum MapSkin

--- a/AWBWApp.Game/Game/Logic/PlayerInfo.cs
+++ b/AWBWApp.Game/Game/Logic/PlayerInfo.cs
@@ -19,6 +19,7 @@ namespace AWBWApp.Game.Game.Logic
         public Bindable<FaceDirection> UnitFaceDirection = new Bindable<FaceDirection>();
 
         public BindableBool Eliminated = new BindableBool();
+        public Bindable<int> Clock = new Bindable<int>();
         public Bindable<COInfo> ActiveCO = new Bindable<COInfo>();
         public Bindable<COInfo> TagCO = new Bindable<COInfo>();
         public Bindable<ActiveCOPower> ActivePower = new Bindable<ActiveCOPower>();
@@ -72,6 +73,7 @@ namespace AWBWApp.Game.Game.Logic
             };
 
             ActivePower.Value = activePower;
+            Clock.Value = turn.Clock.Value;
         }
 
         public void UpdateUndo(ReplayUserTurn turn, COStorage coStorage, int turnNumber, int unitCount, int unitValue, int propertyValue, ActiveCOPower activePower)

--- a/AWBWApp.Game/Game/Logic/ReplayController.cs
+++ b/AWBWApp.Game/Game/Logic/ReplayController.cs
@@ -78,6 +78,7 @@ namespace AWBWApp.Game.Game.Logic
         private IBindable<SonjaHPVisibility> sonjaHPVisibility;
 
         public IBindable<bool> ShowAnimationsWhenUnitsHidden;
+        public IBindable<bool> ShowClock;
 
         [Cached(typeof(IBindable<MapSkin>))]
         private Bindable<MapSkin> selectedMapSkin = new Bindable<MapSkin>();
@@ -207,6 +208,8 @@ namespace AWBWApp.Game.Game.Logic
 
             sonjaHPVisibility = configManager.GetBindable<SonjaHPVisibility>(AWBWSetting.SonjaHPVisiblity);
             sonjaHPVisibility.BindValueChanged(x => UpdateFogOfWar());
+
+            ShowClock = configManager.GetBindable<bool>(AWBWSetting.ShowClock);
 
             ShowAnimationsWhenUnitsHidden = configManager.GetBindable<bool>(AWBWSetting.ShowAnimationsForHiddenActions);
 

--- a/AWBWApp.Game/UI/Interrupts/LoginInterrupt.cs
+++ b/AWBWApp.Game/UI/Interrupts/LoginInterrupt.cs
@@ -48,16 +48,17 @@ namespace AWBWApp.Game.UI.Interrupts
                         TabbableContentContainer = this
                     },
                     passwordInput = new BasicPasswordTextBox()
-                    {
-                        PlaceholderText = "Password",
-                        RelativeSizeAxes = Axes.X,
-                        Anchor = Anchor.TopCentre,
-                        Origin = Anchor.TopCentre,
-                        Width = 0.95f,
-                        Margin = new MarginPadding { Top = 5 },
-                        Height = 40,
-                        TabbableContentContainer = this
-                    },
+                            {
+                                PlaceholderText = "Password",
+                                RelativeSizeAxes = Axes.X,
+                                Anchor = Anchor.TopCentre,
+                                Origin = Anchor.TopCentre,
+                                Width = 0.95f,
+                                Margin = new MarginPadding { Top = 5 },
+                                Height = 40,
+                                TabbableContentContainer = this,
+                                CommitOnFocusLost = false
+                            },
                     errorText = new TextFlowContainer()
                     {
                         Anchor = Anchor.TopCentre,
@@ -95,6 +96,8 @@ namespace AWBWApp.Game.UI.Interrupts
                     }
                 }
             );
+            
+            passwordInput.OnCommit += onPasswordBoxCommit;
 
             Add(blockingLayer = new LoadingLayer(true)
             {
@@ -105,6 +108,10 @@ namespace AWBWApp.Game.UI.Interrupts
         private void scheduleLogin()
         {
             Schedule(attemptLogin);
+        }
+        private void onPasswordBoxCommit(TextBox sender, bool newText)
+        {
+            scheduleLogin();
         }
 
         private async void attemptLogin()

--- a/AWBWApp.Game/UI/Interrupts/LoginInterrupt.cs
+++ b/AWBWApp.Game/UI/Interrupts/LoginInterrupt.cs
@@ -48,17 +48,17 @@ namespace AWBWApp.Game.UI.Interrupts
                         TabbableContentContainer = this
                     },
                     passwordInput = new BasicPasswordTextBox()
-                            {
-                                PlaceholderText = "Password",
-                                RelativeSizeAxes = Axes.X,
-                                Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
-                                Width = 0.95f,
-                                Margin = new MarginPadding { Top = 5 },
-                                Height = 40,
-                                TabbableContentContainer = this,
-                                CommitOnFocusLost = false
-                            },
+                    {
+                        PlaceholderText = "Password",
+                        RelativeSizeAxes = Axes.X,
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Width = 0.95f,
+                        Margin = new MarginPadding { Top = 5 },
+                        Height = 40,
+                        TabbableContentContainer = this,
+                        CommitOnFocusLost = false
+                    },
                     errorText = new TextFlowContainer()
                     {
                         Anchor = Anchor.TopCentre,

--- a/AWBWApp.Game/UI/Replay/ReplayPlayerList.cs
+++ b/AWBWApp.Game/UI/Replay/ReplayPlayerList.cs
@@ -197,7 +197,7 @@ namespace AWBWApp.Game.UI.Replay
 
                 foreach (var player in players)
                 {
-                    var drawable = new ReplayPlayerListItem(this, player.Value, x => controller.Stats.ShowStatsForPlayer(controller.Players, x), usePercentagePowers, x => controller.Map.GetDrawableUnitsFromPlayer(x).ToList());
+                    var drawable = new ReplayPlayerListItem(this, player.Value, x => controller.Stats.ShowStatsForPlayer(controller.Players, x), usePercentagePowers, x => controller.Map.GetDrawableUnitsFromPlayer(x).ToList(), controller.ShowClock);
                     drawablePlayers.Add(drawable);
                     fillContainer.Add(drawable);
                 }

--- a/AWBWApp.Game/UI/Toolbar/MainControlMenuBar.cs
+++ b/AWBWApp.Game/UI/Toolbar/MainControlMenuBar.cs
@@ -62,6 +62,7 @@ namespace AWBWApp.Game.UI.Toolbar
                         new ToggleMenuItem("Show Animations for Hidden Actions", configManager.GetBindable<bool>(AWBWSetting.ShowAnimationsForHiddenActions)),
                         new ToggleMenuItem("Skip End Turn Animations", configManager.GetBindable<bool>(AWBWSetting.ReplaySkipEndTurn)),
                         new EnumMenuItem<SonjaHPVisibility>("Sonja HP Visibility", configManager.GetBindable<SonjaHPVisibility>(AWBWSetting.SonjaHPVisiblity)),
+                        new ToggleMenuItem("Show Clock", configManager.GetBindable<bool>(AWBWSetting.ShowClock)),
                         new EnumMenuItem<Anchor>("Tile Info Popup Anchor", configManager.GetBindable<Anchor>(AWBWSetting.TileInfoPopupAnchor),
                             new[]
                             {

--- a/AWBWApp.Resources/Json/Units.json
+++ b/AWBWApp.Resources/Json/Units.json
@@ -634,7 +634,7 @@
         "AWBWId": 46,
         "MaxFuel": 99,
         "MaxAmmo": 9,
-        "FuelUsagePerTurn": 1,
+        "FuelUsagePerTurn": 0,
         "Vision": 1,
         "MovementRange": 6,
         "AttackRange": {"x": 1, "y": 1},


### PR DESCRIPTION
The neotank desync was caused by 'FuelUsagePerTurn' being set to 1 instead of 0.

CP of destroyed pipeseams is basically undefined, so I removed them from the equality check for buildings. How AWBW handles them is inconsistent; in the LL games I checked, the following happens:

- The turn a seam is destroyed, its CP is set to the last value of the undestroyed seam.
- The turn after, its CP is set to 20 and keeps this value for the rest of the game.

However, in one of my test games (ID: 1121885), the CP is set to 20 in the turn the seam is destroyed.