### PR TITLE
add visual setting to lock map position

### DIFF
--- a/AWBWApp.Game/AWBWConfigManager.cs
+++ b/AWBWApp.Game/AWBWConfigManager.cs
@@ -63,6 +63,7 @@ namespace AWBWApp.Game
             SetDefault(AWBWSetting.ShowAnimationsForHiddenActions, true);
             SetDefault(AWBWSetting.SonjaHPVisiblity, SonjaHPVisibility.AlwaysVisible);
             SetDefault(AWBWSetting.ShowClock, true);
+            SetDefault(AWBWSetting.LockMapPosition, false);
 
             SetDefault(AWBWSetting.MapGridBaseColour, new Colour4(42, 91, 139, 255).Lighten(0.2f));
             SetDefault(AWBWSetting.MapGridGridColour, new Colour4(42, 91, 139, 255).Darken(0.8f));
@@ -96,7 +97,8 @@ namespace AWBWApp.Game
         MapGridBaseColour,
         MapGridGridColour,
         SonjaHPVisiblity,
-        ShowClock
+        ShowClock,
+        LockMapPosition
     }
 
     public enum MapSkin

--- a/AWBWApp.Game/UI/CameraControllerWithGrid.cs
+++ b/AWBWApp.Game/UI/CameraControllerWithGrid.cs
@@ -34,6 +34,7 @@ namespace AWBWApp.Game.UI
         private IBindable<bool> allowLeftMouseToDragUserOption;
         private IBindable<Colour4> baseMapColour;
         private IBindable<Colour4> baseGridColour;
+        private Bindable<bool> lockMapPosition;
 
         public CameraControllerWithGrid()
         {
@@ -70,6 +71,8 @@ namespace AWBWApp.Game.UI
 
             baseGridColour = configManager.GetBindable<Colour4>(AWBWSetting.MapGridGridColour);
             baseGridColour.BindValueChanged(x => grid.GridColor = x.NewValue, true);
+
+            lockMapPosition = configManager.GetBindable<bool>(AWBWSetting.LockMapPosition);
         }
 
         //Todo: Center it as well
@@ -95,6 +98,11 @@ namespace AWBWApp.Game.UI
 
         protected override bool OnScroll(ScrollEvent e)
         {
+            if (lockMapPosition.Value) // disable zoom if map is locked
+            {
+                return false;
+            }
+
             var cursorPosition = ToParentSpace(e.MousePosition);
             var offset = content.AnchorPosition + content.Position;
 
@@ -119,6 +127,9 @@ namespace AWBWApp.Game.UI
 
         protected override bool OnDragStart(DragStartEvent e)
         {
+            if (lockMapPosition.Value) { // disable drag if map is locked
+                return false;
+            }
             if (e.Button == MouseButton.Left)
             {
                 if (!AllowLeftMouseToDrag || !allowLeftMouseToDragUserOption.Value)

--- a/AWBWApp.Game/UI/CameraControllerWithGrid.cs
+++ b/AWBWApp.Game/UI/CameraControllerWithGrid.cs
@@ -34,7 +34,7 @@ namespace AWBWApp.Game.UI
         private IBindable<bool> allowLeftMouseToDragUserOption;
         private IBindable<Colour4> baseMapColour;
         private IBindable<Colour4> baseGridColour;
-        private Bindable<bool> lockMapPosition;
+        private IBindable<bool> lockMapPosition;
 
         public CameraControllerWithGrid()
         {
@@ -98,10 +98,7 @@ namespace AWBWApp.Game.UI
 
         protected override bool OnScroll(ScrollEvent e)
         {
-            if (lockMapPosition.Value) // disable zoom if map is locked
-            {
-                return false;
-            }
+            if (lockMapPosition.Value) return false; // disable zoom if map is locked
 
             var cursorPosition = ToParentSpace(e.MousePosition);
             var offset = content.AnchorPosition + content.Position;
@@ -127,9 +124,8 @@ namespace AWBWApp.Game.UI
 
         protected override bool OnDragStart(DragStartEvent e)
         {
-            if (lockMapPosition.Value) { // disable drag if map is locked
-                return false;
-            }
+            if (lockMapPosition.Value) return false; // disable drag if map is locked
+
             if (e.Button == MouseButton.Left)
             {
                 if (!AllowLeftMouseToDrag || !allowLeftMouseToDragUserOption.Value)

--- a/AWBWApp.Game/UI/Toolbar/MainControlMenuBar.cs
+++ b/AWBWApp.Game/UI/Toolbar/MainControlMenuBar.cs
@@ -76,6 +76,7 @@ namespace AWBWApp.Game.UI.Toolbar
                                 Anchor.BottomRight,
                             }
                         ),
+                        new ToggleMenuItem("Lock Map Position", configManager.GetBindable<bool>(AWBWSetting.LockMapPosition)),
                     }
                 },
                 new MenuItem("Control Settings")


### PR DESCRIPTION
Using the existing hack from the Replay Carousel to implement a simple map lock feature, as I've often heard it requested by streamers/youtubers. 😄 

![image](https://github.com/user-attachments/assets/67f92075-acea-4baa-b36c-6ce1665eaec4)

I did some basic testing but I'm overriding all `OnScroll` and `OnDragStart` events in `CameraControllerWithGrid.cs`, and I'm not intimately familiar with this application in the first place. So a second pair of eyes to make sure I'm not suppressing something important would be nice!