### PR TITLE
Set up a CI with Github Actions

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,25 @@
+name: .NET
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -22,4 +22,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal --filter "TestCategory!=NoCI"

--- a/AWBWApp.Game.Tests/Replays/TestReplayParsing.cs
+++ b/AWBWApp.Game.Tests/Replays/TestReplayParsing.cs
@@ -8,6 +8,7 @@ using osu.Framework.Platform;
 namespace AWBWApp.Game.Tests.Replays
 {
     [TestFixture]
+    [Category("NoCI")]
     public class TestReplayParsing
     {
         //Todo: This test doesn't really work outside of a desktop environment.

--- a/AWBWApp.Game.Tests/Visual/Logic/TestSceneGameMap.cs
+++ b/AWBWApp.Game.Tests/Visual/Logic/TestSceneGameMap.cs
@@ -47,6 +47,7 @@ namespace AWBWApp.Game.Tests.Visual.Logic
         }
 
         [Test]
+        [Category("NoCI")] // because this test needs to be manually updated, it is unfit to be run in CI
         public void TestDownloadMapAndRun()
         {
             //Note due to how AWBW functions, this test needs to be updated once every 1-2 weeks for it to not fail in headless.


### PR DESCRIPTION
This PR proposes a simple Github Actions workflow to run tests in Github on every PR and push to `master`.

Because two tests are unfit for being run in a CI, they are added to a category "NoCI" and disabled specifically with 

```sh
dotnet test --no-build --verbosity normal --filter "TestCategory!=NoCI"
```

# Flaky `TestReplayScreen` test
However, one test causes problems. It will sometimes pass and sometimes fail, apparently because of concurrent loading of a zip file. 
See:
- here is a test run passing: https://github.com/Dune-jr/AWBW-Replay-Player/actions/runs/13435161066/attempts/1
- here is a test run failing: https://github.com/Dune-jr/AWBW-Replay-Player/actions/runs/13435161066/attempts/2
(This is on the same commit ID https://github.com/Dune-jr/AWBW-Replay-Player/pull/1/commits/71d27aa7d2682fae1c6a64364adc5eaae7fa7bc2)

I tried to apply `[NonParallelizable]`, but that does not fix it. I think it's being written and read right afterwards, and it doesn't wait for the file to be closed?

Note, it can be reproduced locally for me:

```log
AWBW-Replay-Player\AWBWApp.Game\IO\WrappedStorage.cs(63): error TESTERROR:
      TestReplayScreen (389ms): Error Message: TearDown : System.IO.IOException : The process cannot access the file 'C:\Users\jordy\AppData\Local\Temp\of-test-
      headless\TestSceneReplaySelect-25cd403d-b282-4ded-bab2-1aff68d297ae\ReplayData\Replays\478996.zip' because it is being used by another process.
      Stack Trace:
```