### PR TITLE
Add map name to replay viewer

### DIFF
--- a/AWBWApp.Game/Game/Logic/GameMap.cs
+++ b/AWBWApp.Game/Game/Logic/GameMap.cs
@@ -63,6 +63,8 @@ namespace AWBWApp.Game.Game.Logic
         private readonly UnitRangeIndicator rangeIndicator;
         protected TileCursor TileCursor;
 
+        public string TerrainName;
+
         private FogOfWarGenerator fogOfWarGenerator;
 
         private readonly EffectAnimationController effectAnimationController;
@@ -170,6 +172,7 @@ namespace AWBWApp.Game.Game.Logic
             loadingMap = ShoalGenerator.CreateCustomShoalVersion(loadingMap);
 
             MapSize = loadingMap.Size;
+            TerrainName = "";
 
             TileGrid.ClearToSize(MapSize);
             BuildingGrid.ClearToSize(MapSize);
@@ -220,6 +223,7 @@ namespace AWBWApp.Game.Game.Logic
             map = ShoalGenerator.CreateCustomShoalVersion(map);
 
             MapSize = map.Size;
+            TerrainName = map.TerrainName;
 
             //Calculate the map size as this isn't given by the api
             //Todo: Check buildings

--- a/AWBWApp.Game/Game/Logic/ReplayController.cs
+++ b/AWBWApp.Game/Game/Logic/ReplayController.cs
@@ -352,7 +352,7 @@ namespace AWBWApp.Game.Game.Logic
                 CurrentTurnIndex.Value = 0;
 
                 setupActions();
-                updatePlayerList(0, true, false);
+                updatePlayerList(0, reset: true, undo: false);
 
                 Map.SetToInitialGameState(this.replayData, map);
 
@@ -361,7 +361,7 @@ namespace AWBWApp.Game.Game.Logic
                 {
                     HasLoadedReplay = true;
                     UpdateFogOfWar();
-                    updatePlayerList(0, false, false);
+                    updatePlayerList(0, reset: false, undo: false);
                     cameraControllerWithGrid.FitMapToSpace();
                     CurrentTurnIndex.TriggerChange();
                     updateReplayBarActions();

--- a/AWBWApp.Game/Game/Logic/ReplayController.cs
+++ b/AWBWApp.Game/Game/Logic/ReplayController.cs
@@ -817,6 +817,8 @@ namespace AWBWApp.Game.Game.Logic
             }
 
             playerList.SortList(currentTurn.ActivePlayerID, turnIdx);
+            if (HasLoadedReplay)
+                playerList.UpdateTerrainName();
         }
 
         public void UpdateFogOfWar()

--- a/AWBWApp.Game/UI/Replay/ReplayPlayerList.cs
+++ b/AWBWApp.Game/UI/Replay/ReplayPlayerList.cs
@@ -13,6 +13,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Lists;
 using osuTK;
 using osuTK.Graphics;
@@ -22,7 +23,8 @@ namespace AWBWApp.Game.UI.Replay
     public partial class ReplayPlayerList : Container, IHasContextMenu
     {
         public ReplayBarWidget ReplayBarWidget;
-        public ReplayController controller;
+        public ReplayController Controller;
+        public SpriteText TerrainNameSprite;
 
         private FillFlowContainer fillContainer;
 
@@ -44,7 +46,7 @@ namespace AWBWApp.Game.UI.Replay
 
         public ReplayPlayerList(ReplayController controller)
         {
-            this.controller = controller;
+            this.Controller = controller;
             Masking = true;
             EdgeEffect = new EdgeEffectParameters
             {
@@ -109,7 +111,18 @@ namespace AWBWApp.Game.UI.Replay
                             Origin = Anchor.BottomCentre,
                         }
                     }
-                }
+                },
+                TerrainNameSprite = new SpriteText()
+                {
+                    Anchor = Anchor.BottomCentre,
+                    Origin = Anchor.BottomCentre,
+                    Colour = Color4.White,
+                    Padding = new MarginPadding { Left = 3 },
+                    Shadow = true,
+                    Truncate = true,
+                    Font = FontUsage.Default.With(size: 18),
+                    Text = "Map: " + Controller.Map.TerrainName,
+                },
             };
 
             fogDropdown.Current.BindTo(controller.CurrentFogView);
@@ -287,6 +300,11 @@ namespace AWBWApp.Game.UI.Replay
 
                 fillContainer.SetLayoutPosition(player, i);
             }
+        }
+
+        public void UpdateTerrainName()
+        {
+            TerrainNameSprite.Text = "Map: " + Controller.Map.TerrainName;
         }
 
         public MenuItem[] ContextMenuItems { get; private set; }

--- a/AWBWApp.Game/UI/Replay/ReplayPlayerList.cs
+++ b/AWBWApp.Game/UI/Replay/ReplayPlayerList.cs
@@ -197,7 +197,13 @@ namespace AWBWApp.Game.UI.Replay
 
                 foreach (var player in players)
                 {
-                    var drawable = new ReplayPlayerListItem(this, player.Value, x => controller.Stats.ShowStatsForPlayer(controller.Players, x), usePercentagePowers, x => controller.Map.GetDrawableUnitsFromPlayer(x).ToList(), controller.ShowClock);
+                    var drawable = new ReplayPlayerListItem(
+                        playerList: this,
+                        info: player.Value,
+                        openPlayerStats: x => controller.Stats.ShowStatsForPlayer(controller.Players, x),
+                        usePercentagePowers: usePercentagePowers,
+                        getUnits: x => controller.Map.GetDrawableUnitsFromPlayer(x).ToList(),
+                        ShowClock: controller.ShowClock);
                     drawablePlayers.Add(drawable);
                     fillContainer.Add(drawable);
                 }

--- a/AWBWApp.Game/UI/Replay/ReplayPlayerListItem.cs
+++ b/AWBWApp.Game/UI/Replay/ReplayPlayerListItem.cs
@@ -70,7 +70,7 @@ namespace AWBWApp.Game.UI.Replay
         private bool usePercentagePowers;
         private float unitPriceMultiplier;
         private ReplayPlayerList playerList;
-        private List<DrawableUnit> tooltipContent;
+        // private List<DrawableUnit> tooltipContent; // TODO: unused?
 
         public ReplayPlayerListItem(ReplayPlayerList playerList, PlayerInfo info, Action<long> openPlayerStats, bool usePercentagePowers, Func<long, List<DrawableUnit>> getUnits, IBindable<bool> ShowClock)
         {


### PR DESCRIPTION
Closes #133 

### Description
This adds a "Map: XXX" label in the simplest way possible. I do not have design skills, so maybe you want to improve on that - put it in a box or something.

- I had to pass the `TerrainName` information around in the code, maybe 1b7d182096bf1b3d3d13773eeb9e453d24405717 could have been lighter but I did not find a way how.
- Tiny changes because of some warnings and lenghty parameters list giving me a headache - addd7af428b59c130633b1f4e22d3048ac958c10 and 04a55526fdf8caab41fcd866146dda9a9ebb9186. They can be dropped if you prefer.

### Screenshot
![image](https://github.com/user-attachments/assets/ca5d16e6-182c-4074-b258-01bc2fcda5a0)
